### PR TITLE
Add pagination to clean architecture student and teacher listings

### DIFF
--- a/src/main/java/sptech/school/v2/cleanarch/core/application/facades/student/StudentFacade.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/application/facades/student/StudentFacade.java
@@ -1,5 +1,7 @@
 package sptech.school.v2.cleanarch.core.application.facades.student;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import sptech.school.v2.cleanarch.domain.entities.Student;
 import sptech.school.v2.cleanarch.domain.exception.UserNullException;
@@ -7,10 +9,8 @@ import sptech.school.v2.cleanarch.core.application.usecases.student.StudentComma
 import sptech.school.v2.cleanarch.core.application.usecases.student.StudentQueryUseCase;
 import sptech.school.v2.cleanarch.core.application.utils.VerifyEmailAndCpfUtil;
 
-import java.util.List;
-
 @Service
-public class StudentFacade implements StudentFacadeContract{
+public class StudentFacade implements StudentFacadeContract {
     private final StudentCommandUseCase studentCommandUseCase;
     private final StudentQueryUseCase studentQueryUseCase;
     private final VerifyEmailAndCpfUtil verifyEmailAndCpfUtil;
@@ -28,8 +28,8 @@ public class StudentFacade implements StudentFacadeContract{
     }
 
     @Override
-    public List<Student> listAll() {
-        return studentQueryUseCase.listAll();
+    public Page<Student> listAll(Pageable pageable) {
+        return studentQueryUseCase.listAll(pageable);
     }
 
     @Override

--- a/src/main/java/sptech/school/v2/cleanarch/core/application/facades/student/StudentFacadeContract.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/application/facades/student/StudentFacadeContract.java
@@ -1,12 +1,12 @@
 package sptech.school.v2.cleanarch.core.application.facades.student;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import sptech.school.v2.cleanarch.domain.entities.Student;
-
-import java.util.List;
 
 public interface StudentFacadeContract {
     Student create(Student student);
-    List<Student> listAll();
+    Page<Student> listAll(Pageable pageable);
     Student update(Student student, Integer id);
     void delete(Integer id);
     Student findById(Integer id);

--- a/src/main/java/sptech/school/v2/cleanarch/core/application/facades/teacher/TeacherFacade.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/application/facades/teacher/TeacherFacade.java
@@ -1,6 +1,8 @@
 package sptech.school.v2.cleanarch.core.application.facades.teacher;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import sptech.school.application.usecase.StorageServiceUseCase;
 import sptech.school.v2.cleanarch.domain.entities.ResourceFile;
@@ -13,7 +15,6 @@ import sptech.school.v2.cleanarch.core.application.utils.VerifyEmailAndCpfUtil;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -73,8 +74,8 @@ public class TeacherFacade implements TeacherFacadeContract {
     }
 
     @Override
-    public List<Teacher> listAll() {
-        List<Teacher> teachers = teacherQueryUseCase.listAll();
+    public Page<Teacher> listAll(Pageable pageable) {
+        Page<Teacher> teachers = teacherQueryUseCase.listAll(pageable);
         teachers.forEach(this::loadProfileImage);
         return teachers;
     }

--- a/src/main/java/sptech/school/v2/cleanarch/core/application/facades/teacher/TeacherFacadeContract.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/application/facades/teacher/TeacherFacadeContract.java
@@ -1,8 +1,8 @@
 package sptech.school.v2.cleanarch.core.application.facades.teacher;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import sptech.school.v2.cleanarch.domain.entities.Teacher;
-
-import java.util.List;
 
 /**
  Para adicionar novos métodos, siga os passos:
@@ -18,7 +18,7 @@ import java.util.List;
  */
 public interface TeacherFacadeContract {
     Teacher create(Teacher teacher);
-    List<Teacher> listAll();
+    Page<Teacher> listAll(Pageable pageable);
     Teacher update(Teacher teacher, Integer id);
     void delete(Integer id);
     Boolean teacherExistsByEmail(String email);

--- a/src/main/java/sptech/school/v2/cleanarch/core/application/gateways/student/StudentQueryGateway.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/application/gateways/student/StudentQueryGateway.java
@@ -2,7 +2,8 @@ package sptech.school.v2.cleanarch.core.application.gateways.student;
 
 import sptech.school.v2.cleanarch.domain.entities.Student;
 
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import java.util.Optional;
 
 public interface StudentQueryGateway {
@@ -12,7 +13,7 @@ public interface StudentQueryGateway {
 
     Student findById(Integer id);
 
-    List<Student> listAll();
+    Page<Student> listAll(Pageable pageable);
 
     Optional<Student> findByEmail(String email);
 }

--- a/src/main/java/sptech/school/v2/cleanarch/core/application/gateways/teacher/TeacherQueryGateway.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/application/gateways/teacher/TeacherQueryGateway.java
@@ -1,8 +1,9 @@
 package sptech.school.v2.cleanarch.core.application.gateways.teacher;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import sptech.school.v2.cleanarch.domain.entities.Teacher;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -17,7 +18,7 @@ public interface TeacherQueryGateway {
 
     Teacher findById(Integer id);
 
-    List<Teacher> listAll();
+    Page<Teacher> listAll(Pageable pageable);
 
     Optional<Teacher> findByEmail(String email);
 }

--- a/src/main/java/sptech/school/v2/cleanarch/core/application/usecases/student/StudentQueryUseCase.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/application/usecases/student/StudentQueryUseCase.java
@@ -1,10 +1,11 @@
 package sptech.school.v2.cleanarch.core.application.usecases.student;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import sptech.school.v2.cleanarch.domain.entities.Student;
 import sptech.school.v2.cleanarch.core.application.gateways.student.StudentQueryGateway;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -26,8 +27,9 @@ public class StudentQueryUseCase {
     public Student findById(Integer id) {
         return studentQueryGateway.findById(id);
     }
-    public List<Student> listAll() {
-        return studentQueryGateway.listAll();
+
+    public Page<Student> listAll(Pageable pageable) {
+        return studentQueryGateway.listAll(pageable);
     }
 
     public Optional<Student> findByEmail(String email) {

--- a/src/main/java/sptech/school/v2/cleanarch/core/application/usecases/teacher/TeacherQueryUseCase.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/application/usecases/teacher/TeacherQueryUseCase.java
@@ -1,10 +1,11 @@
 package sptech.school.v2.cleanarch.core.application.usecases.teacher;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import sptech.school.v2.cleanarch.domain.entities.Teacher;
 import sptech.school.v2.cleanarch.core.application.gateways.teacher.TeacherQueryGateway;
 
-import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -27,8 +28,8 @@ public class TeacherQueryUseCase {
         return teacherQueryGateway.teacherExistsByEmail(email);
     }
 
-    public List<Teacher> listAll() {
-        return teacherQueryGateway.listAll();
+    public Page<Teacher> listAll(Pageable pageable) {
+        return teacherQueryGateway.listAll(pageable);
     }
 
     public Optional<Teacher> findByEmail(String email) {

--- a/src/main/java/sptech/school/v2/cleanarch/infra/persistence/adapter/student/StudentQueryJpaAdapter.java
+++ b/src/main/java/sptech/school/v2/cleanarch/infra/persistence/adapter/student/StudentQueryJpaAdapter.java
@@ -1,11 +1,12 @@
 package sptech.school.v2.cleanarch.infra.persistence.adapter.student;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import sptech.school.v2.cleanarch.domain.entities.Student;
 import sptech.school.v2.cleanarch.core.application.gateways.student.StudentQueryGateway;
 import sptech.school.v2.cleanarch.infra.persistence.repository.StudentJpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -32,8 +33,8 @@ public class StudentQueryJpaAdapter implements StudentQueryGateway {
     }
 
     @Override
-    public List<Student> listAll() {
-        return repository.findAll();
+    public Page<Student> listAll(Pageable pageable) {
+        return repository.findAll(pageable);
     }
 
     @Override

--- a/src/main/java/sptech/school/v2/cleanarch/infra/persistence/adapter/teacher/TeacherQueryJpaAdapter.java
+++ b/src/main/java/sptech/school/v2/cleanarch/infra/persistence/adapter/teacher/TeacherQueryJpaAdapter.java
@@ -1,11 +1,12 @@
 package sptech.school.v2.cleanarch.infra.persistence.adapter.teacher;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 import sptech.school.v2.cleanarch.domain.entities.Teacher;
 import sptech.school.v2.cleanarch.core.application.gateways.teacher.TeacherQueryGateway;
 import sptech.school.v2.cleanarch.infra.persistence.repository.TeacherJpaRepository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Component
@@ -33,8 +34,8 @@ public class TeacherQueryJpaAdapter implements TeacherQueryGateway {
     }
 
     @Override
-    public List<Teacher> listAll() {
-        return teacherJpaRepository.findAll();
+    public Page<Teacher> listAll(Pageable pageable) {
+        return teacherJpaRepository.findAll(pageable);
     }
 
     @Override

--- a/src/main/java/sptech/school/v2/cleanarch/infra/web/StudentController.java
+++ b/src/main/java/sptech/school/v2/cleanarch/infra/web/StudentController.java
@@ -7,6 +7,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sptech.school.v2.cleanarch.domain.entities.Student;
@@ -106,16 +110,27 @@ public class StudentController {
     @GetMapping
     @Operation(
             summary = "Lista estudantes",
-            description = "Retorna uma lista com todos os estudantes cadastrados. Pode retornar lista vazia."
+            description = "Retorna estudantes paginados. Pode retornar lista vazia."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso")
     })
-    public ResponseEntity<List<StudentResponseDTO>> findAllStudents() {
-        List<StudentResponseDTO> dtos = studentFacade.listAll()
+    public ResponseEntity<Page<StudentResponseDTO>> findAllStudents(
+            @Parameter(description = "Página a ser recuperada", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Quantidade de itens por página", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        int pageNumber = Math.max(page, 0);
+        int pageSize = Math.max(size, 1);
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+
+        Page<Student> students = studentFacade.listAll(pageable);
+        List<StudentResponseDTO> dtos = students.getContent()
                 .stream()
                 .map(studentMapper::toDtoResponse)
                 .toList();
-        return ResponseEntity.ok(dtos);
+        Page<StudentResponseDTO> dtoPage = new PageImpl<>(dtos, students.getPageable(), students.getTotalElements());
+        return ResponseEntity.ok(dtoPage);
     }
 }

--- a/src/main/java/sptech/school/v2/cleanarch/infra/web/TeacherController.java
+++ b/src/main/java/sptech/school/v2/cleanarch/infra/web/TeacherController.java
@@ -7,6 +7,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sptech.school.v2.cleanarch.domain.entities.Teacher;
@@ -106,16 +110,27 @@ public class TeacherController {
     @GetMapping
     @Operation(
             summary = "Lista professores",
-            description = "Retorna uma lista com todos os professores cadastrados. Pode retornar lista vazia."
+            description = "Retorna professores paginados. Pode retornar lista vazia."
     )
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "Lista retornada com sucesso")
     })
-    public ResponseEntity<List<TeacherResponseDTO>> findAllTeachers() {
-        List<TeacherResponseDTO> dtos = teacherFacade.listAll()
+    public ResponseEntity<Page<TeacherResponseDTO>> findAllTeachers(
+            @Parameter(description = "Página a ser recuperada", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Quantidade de itens por página", example = "10")
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        int pageNumber = Math.max(page, 0);
+        int pageSize = Math.max(size, 1);
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+
+        Page<Teacher> teachers = teacherFacade.listAll(pageable);
+        List<TeacherResponseDTO> dtos = teachers.getContent()
                 .stream()
                 .map(teacherMapper::toDtoResponse)
                 .toList();
-        return ResponseEntity.ok(dtos);
+        Page<TeacherResponseDTO> dtoPage = new PageImpl<>(dtos, teachers.getPageable(), teachers.getTotalElements());
+        return ResponseEntity.ok(dtoPage);
     }
 }


### PR DESCRIPTION
## Summary
- implement pageable list endpoints for students and teachers in the clean architecture controllers
- propagate pagination through facades, use cases, and JPA adapters for student and teacher queries

## Testing
- ./mvnw -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68ec2ce8f4e48321824df295b1c314a0