### PR TITLE
Avoid caching PageImpl in teacher listings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,10 +53,15 @@
 			<version>2.25.15</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-mail</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-mail</artifactId>
+                </dependency>
+
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-data-redis</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/sptech/school/v2/cleanarch/config/CacheConfig.java
+++ b/src/main/java/sptech/school/v2/cleanarch/config/CacheConfig.java
@@ -1,28 +1,86 @@
 package sptech.school.v2.cleanarch.config;
 
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.cache.interceptor.SimpleCacheErrorHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 /**
  * Configuração de Cache com Redis para a aplicação Studi.
  *
- * Esta classe ativa o suporte a cache na aplicação.
- * O Spring Boot autoconfiguration cuida de conectar com Redis
- * baseado nas propriedades configuradas em application.properties.
- *
- * O cache é utilizado nos endpoints de Teacher para otimizar a performance.
- *
- * Configuração esperada em application.properties:
- * - spring.cache.type=redis
- * - spring.redis.host=localhost
- * - spring.redis.port=6379
- * - spring.cache.redis.time-to-live=3600000
+ * O cache usa {@link GenericJackson2JsonRedisSerializer} serializando valores
+ * como {@code Object}, garantindo que DTOs/entidades sejam armazenados em vez de
+ * {@code ResponseEntity} (que não deve ser colocado no cache).
  */
 @Configuration
 @EnableCaching
 public class CacheConfig {
-    // Spring Boot autoconfiguration cuida de tudo
-    // Nenhuma bean customizada necessária
+
+    @Bean
+    public RedisCacheConfiguration redisCacheConfiguration() {
+        GenericJackson2JsonRedisSerializer valueSerializer = new GenericJackson2JsonRedisSerializer();
+
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(valueSerializer));
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        return RedisCacheManager.builder(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration())
+                .build();
+    }
+
+    @Bean
+    public CacheErrorHandler cacheErrorHandler() {
+        // Evita que entradas antigas (ex.: PageImpl/ResponseEntity) causem erros na desserialização.
+        // Ao encontrar erro no cache, removemos a chave problemática e seguimos executando o método.
+        return new SimpleCacheErrorHandler() {
+            @Override
+            public void handleCacheGetError(RuntimeException exception, org.springframework.cache.Cache cache, Object key) {
+                evictQuietly(cache, key);
+            }
+
+            @Override
+            public void handleCachePutError(RuntimeException exception, org.springframework.cache.Cache cache, Object key, Object value) {
+                evictQuietly(cache, key);
+            }
+
+            @Override
+            public void handleCacheEvictError(RuntimeException exception, org.springframework.cache.Cache cache, Object key) {
+                evictQuietly(cache, key);
+            }
+
+            @Override
+            public void handleCacheClearError(RuntimeException exception, org.springframework.cache.Cache cache) {
+                evictQuietly(cache, null);
+            }
+
+            private void evictQuietly(org.springframework.cache.Cache cache, Object key) {
+                if (cache == null) {
+                    return;
+                }
+                try {
+                    if (key != null) {
+                        cache.evict(key);
+                    } else {
+                        cache.clear();
+                    }
+                } catch (RuntimeException ignored) {
+                    // Evita que o erro de serialização impeça a leitura do endpoint.
+                }
+            }
+        };
+    }
 }
 
 

--- a/src/main/java/sptech/school/v2/cleanarch/core/application/facades/teacher/TeacherFacade.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/application/facades/teacher/TeacherFacade.java
@@ -1,6 +1,7 @@
 package sptech.school.v2.cleanarch.core.application.facades.teacher;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -47,6 +48,7 @@ public class TeacherFacade implements TeacherFacadeContract {
     }
 
     @Override
+    @CacheEvict(cacheNames = "teacher", allEntries = true)
     public Teacher create(Teacher teacher) {
         verifyEmailAndCpfUtil.verify(teacher);
         Teacher created = teacherCommandUseCase.create(teacher);
@@ -67,6 +69,7 @@ public class TeacherFacade implements TeacherFacadeContract {
     }
 
     @Override
+    @CacheEvict(cacheNames = "teacher", allEntries = true)
     public Teacher update(Teacher teacher, Integer id) {
         verifyEmailAndCpfUtil.verify(teacher, id);
         teacher.setId(id);
@@ -76,6 +79,7 @@ public class TeacherFacade implements TeacherFacadeContract {
     }
 
     @Override
+    @CacheEvict(cacheNames = "teacher", allEntries = true)
     public void delete(Integer id) {
         if (findById(id) == null) {
             throw new UserNullException("Teacher dont exist");
@@ -103,6 +107,7 @@ public class TeacherFacade implements TeacherFacadeContract {
     }
 
     @Override
+    @CacheEvict(cacheNames = "teacher", allEntries = true)
     public ResourceFileResponseDTO uploadProfileImage(MultipartFile file, Integer id) throws IOException {
         if (file == null || file.isEmpty()) {
             throw new IllegalArgumentException("File must not be null or empty");

--- a/src/main/java/sptech/school/v2/cleanarch/core/application/services/cache/TeacherCacheService.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/application/services/cache/TeacherCacheService.java
@@ -1,27 +1,82 @@
 package sptech.school.v2.cleanarch.core.application.services.cache;
 
+import jakarta.annotation.PostConstruct;
 import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import sptech.school.v2.cleanarch.core.application.facades.teacher.TeacherFacadeContract;
+import sptech.school.v2.cleanarch.core.application.mappers.TeacherMapper;
+import sptech.school.v2.cleanarch.core.dtos.out.teacher.TeacherPageResponseDTO;
+import sptech.school.v2.cleanarch.core.dtos.out.teacher.TeacherResponseDTO;
+import sptech.school.v2.cleanarch.domain.entities.Teacher;
+
+import java.util.List;
 
 /**
- * Serviço para gerenciamento de cache de Teacher.
- *
- * Este serviço encapsula operações de limpeza e invalidação de cache,
- * seguindo os padrões de Clean Architecture e Single Responsibility Principle.
- *
- * Casos de uso:
- * - Invalidar cache de um professor específico
- * - Limpar todo o cache de professores
- * - Consultar estado do cache
+ * Serviço para gerenciamento e leitura de cache de Teacher.
+ * <p>
+ * Os métodos anotados com cache retornam DTOs/entidades serializáveis, evitando
+ * qualquer tentativa de serializar {@code ResponseEntity} no Redis.
  */
 @Service
 public class TeacherCacheService {
 
     private static final String TEACHER_CACHE_NAME = "teacher";
     private final CacheManager cacheManager;
+    private final TeacherFacadeContract teacherFacade;
+    private final TeacherMapper teacherMapper;
 
-    public TeacherCacheService(CacheManager cacheManager) {
+    public TeacherCacheService(CacheManager cacheManager,
+                               TeacherFacadeContract teacherFacade,
+                               TeacherMapper teacherMapper) {
         this.cacheManager = cacheManager;
+        this.teacherFacade = teacherFacade;
+        this.teacherMapper = teacherMapper;
+    }
+
+    @PostConstruct
+    public void clearLegacyTeacherCache() {
+        // Remove qualquer entrada antiga que possa ter sido serializada como ResponseEntity
+        clearTeacherCache();
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void clearTeacherCacheWhenAppStarts() {
+        // Garante que qualquer valor persistido antes das correções (PageImpl/ResponseEntity) seja removido.
+        clearTeacherCache();
+    }
+
+    @Cacheable(cacheNames = TEACHER_CACHE_NAME, key = "#id", unless = "#result == null")
+    public TeacherResponseDTO getTeacherById(Integer id) {
+        Teacher found = teacherFacade.findById(id);
+        return found != null ? teacherMapper.toDtoResponse(found) : null;
+    }
+
+    @Cacheable(cacheNames = TEACHER_CACHE_NAME, key = "#page + '_' + #size", unless = "#result == null")
+    public TeacherPageResponseDTO listTeachers(int page, int size) {
+        int pageNumber = Math.max(page, 0);
+        int pageSize = Math.max(size, 1);
+        Pageable pageable = PageRequest.of(pageNumber, pageSize);
+
+        var teachers = teacherFacade.listAll(pageable);
+        List<TeacherResponseDTO> dtos = teachers.getContent()
+                .stream()
+                .map(teacherMapper::toDtoResponse)
+                .toList();
+
+        // Retorna um DTO serializável ao invés de PageImpl para evitar problemas de desserialização no Redis
+        return new TeacherPageResponseDTO(
+                dtos,
+                teachers.getNumber(),
+                teachers.getSize(),
+                teachers.getTotalElements(),
+                teachers.getTotalPages(),
+                teachers.isLast()
+        );
     }
 
     /**

--- a/src/main/java/sptech/school/v2/cleanarch/core/dtos/out/teacher/TeacherPageResponseDTO.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/dtos/out/teacher/TeacherPageResponseDTO.java
@@ -1,0 +1,59 @@
+package sptech.school.v2.cleanarch.core.dtos.out.teacher;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * Representa uma resposta paginada serializável para professores.
+ * <p>
+ * Mantemos apenas dados simples para que o Redis armazene DTOs, evitando
+ * serializar {@code PageImpl}, que não possui construtor padrão.
+ */
+public class TeacherPageResponseDTO implements Serializable {
+
+    private final List<TeacherResponseDTO> content;
+    private final int pageNumber;
+    private final int pageSize;
+    private final long totalElements;
+    private final int totalPages;
+    private final boolean last;
+
+    public TeacherPageResponseDTO(List<TeacherResponseDTO> content,
+                                  int pageNumber,
+                                  int pageSize,
+                                  long totalElements,
+                                  int totalPages,
+                                  boolean last) {
+        this.content = content;
+        this.pageNumber = pageNumber;
+        this.pageSize = pageSize;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.last = last;
+    }
+
+    public List<TeacherResponseDTO> getContent() {
+        return content;
+    }
+
+    public int getPageNumber() {
+        return pageNumber;
+    }
+
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    public long getTotalElements() {
+        return totalElements;
+    }
+
+    public int getTotalPages() {
+        return totalPages;
+    }
+
+    public boolean isLast() {
+        return last;
+    }
+}
+

--- a/src/main/java/sptech/school/v2/cleanarch/core/dtos/out/teacher/TeacherPageResponseDTO.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/dtos/out/teacher/TeacherPageResponseDTO.java
@@ -1,5 +1,7 @@
 package sptech.school.v2.cleanarch.core.dtos.out.teacher;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.io.Serializable;
 import java.util.List;
 
@@ -8,22 +10,40 @@ import java.util.List;
  * <p>
  * Mantemos apenas dados simples para que o Redis armazene DTOs, evitando
  * serializar {@code PageImpl}, que não possui construtor padrão.
+ * <p>
+ * IMPORTANTE: Possui construtor padrão e anotações Jackson para desserialização
+ * correta do Redis (GenericJackson2JsonRedisSerializer).
  */
 public class TeacherPageResponseDTO implements Serializable {
 
-    private final List<TeacherResponseDTO> content;
-    private final int pageNumber;
-    private final int pageSize;
-    private final long totalElements;
-    private final int totalPages;
-    private final boolean last;
+    private static final long serialVersionUID = 1L;
 
-    public TeacherPageResponseDTO(List<TeacherResponseDTO> content,
-                                  int pageNumber,
-                                  int pageSize,
-                                  long totalElements,
-                                  int totalPages,
-                                  boolean last) {
+    private List<TeacherResponseDTO> content;
+    private int pageNumber;
+    private int pageSize;
+    private long totalElements;
+    private int totalPages;
+    private boolean last;
+
+    /**
+     * Construtor padrão (sem argumentos).
+     * NECESSÁRIO para Jackson desserializar do Redis.
+     */
+    public TeacherPageResponseDTO() {
+    }
+
+    /**
+     * Construtor com argumentos - usado pela aplicação.
+     * Anotado com @JsonCreator para Jackson reconhecer como criador alternativo.
+     */
+    @JsonCreator
+    public TeacherPageResponseDTO(
+            @JsonProperty("content") List<TeacherResponseDTO> content,
+            @JsonProperty("pageNumber") int pageNumber,
+            @JsonProperty("pageSize") int pageSize,
+            @JsonProperty("totalElements") long totalElements,
+            @JsonProperty("totalPages") int totalPages,
+            @JsonProperty("last") boolean last) {
         this.content = content;
         this.pageNumber = pageNumber;
         this.pageSize = pageSize;
@@ -32,6 +52,7 @@ public class TeacherPageResponseDTO implements Serializable {
         this.last = last;
     }
 
+    // Getters
     public List<TeacherResponseDTO> getContent() {
         return content;
     }
@@ -54,6 +75,31 @@ public class TeacherPageResponseDTO implements Serializable {
 
     public boolean isLast() {
         return last;
+    }
+
+    // Setters (necessários para deserialização)
+    public void setContent(List<TeacherResponseDTO> content) {
+        this.content = content;
+    }
+
+    public void setPageNumber(int pageNumber) {
+        this.pageNumber = pageNumber;
+    }
+
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    public void setTotalElements(long totalElements) {
+        this.totalElements = totalElements;
+    }
+
+    public void setTotalPages(int totalPages) {
+        this.totalPages = totalPages;
+    }
+
+    public void setLast(boolean last) {
+        this.last = last;
     }
 }
 

--- a/src/main/java/sptech/school/v2/cleanarch/core/dtos/out/teacher/TeacherResponseDTO.java
+++ b/src/main/java/sptech/school/v2/cleanarch/core/dtos/out/teacher/TeacherResponseDTO.java
@@ -7,6 +7,7 @@ import org.hibernate.validator.constraints.br.CPF;
 import org.springframework.web.multipart.MultipartFile;
 import sptech.school.v2.cleanarch.domain.enumerated.Subject;
 
+import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -24,5 +25,5 @@ public record TeacherResponseDTO(
         , String hourlyRate
         , String profileImageContentType
         , byte[] profileImage
-)
-{}
+) implements Serializable {
+}

--- a/src/main/java/sptech/school/v2/cleanarch/infra/web/TeacherController.java
+++ b/src/main/java/sptech/school/v2/cleanarch/infra/web/TeacherController.java
@@ -7,22 +7,19 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import sptech.school.v2.cleanarch.core.dtos.in.teacher.TeacherRegisterDTO;
 import sptech.school.v2.cleanarch.core.dtos.in.teacher.TeacherUpdateDTO;
+import sptech.school.v2.cleanarch.core.dtos.out.teacher.TeacherPageResponseDTO;
 import sptech.school.v2.cleanarch.core.dtos.out.teacher.TeacherResponseDTO;
-import sptech.school.v2.cleanarch.domain.entities.Teacher;
 import sptech.school.v2.cleanarch.core.application.facades.teacher.TeacherFacadeContract;
 import sptech.school.v2.cleanarch.core.application.mappers.TeacherMapper;
-
-import java.util.List;
+import sptech.school.v2.cleanarch.core.application.services.cache.TeacherCacheService;
+import sptech.school.v2.cleanarch.domain.entities.Teacher;
 
 @Tag(name = "Teachers", description = "Operações de CRUD para professores")
 @SecurityRequirement(name = "bearerAuth")
@@ -32,14 +29,15 @@ public class TeacherController {
 
     private final TeacherFacadeContract teacherFacade;
     private final TeacherMapper teacherMapper;
+    private final TeacherCacheService teacherCacheService;
 
-    public TeacherController(TeacherFacadeContract teacherFacade, TeacherMapper teacherMapper) {
+    public TeacherController(TeacherFacadeContract teacherFacade, TeacherMapper teacherMapper, TeacherCacheService teacherCacheService) {
         this.teacherFacade = teacherFacade;
         this.teacherMapper = teacherMapper;
+        this.teacherCacheService = teacherCacheService;
     }
 
     @PostMapping
-    @CacheEvict(cacheNames = "teacher", allEntries = true)
     @Operation(
             summary = "Cria um novo professor",
             description = "Recebe os dados de um professor, aplica validação (@Valid) e o cadastra no sistema."
@@ -56,7 +54,6 @@ public class TeacherController {
     }
 
     @GetMapping("/{id}")
-    @Cacheable(cacheNames = "teacher", key = "#id", unless = "#result == null")
     @Operation(
             summary = "Recupera um professor por ID",
             description = "Retorna os dados de um professor baseado em seu identificador numérico."
@@ -69,12 +66,11 @@ public class TeacherController {
             @Parameter(name = "id", description = "Identificador único do professor", required = true)
             @PathVariable Integer id
     ) {
-        Teacher found = teacherFacade.findById(id);
-        return ResponseEntity.ok(teacherMapper.toDtoResponse(found));
+        TeacherResponseDTO dto = teacherCacheService.getTeacherById(id);
+        return ResponseEntity.ok(dto);
     }
 
     @DeleteMapping("{id}")
-    @CacheEvict(cacheNames = "teacher", allEntries = true)
     @Operation(
             summary = "Deleta um professor por ID",
             description = "Remove permanentemente o professor identificado pelo ID informado."
@@ -92,7 +88,6 @@ public class TeacherController {
     }
 
     @PutMapping("/{id}")
-    @CacheEvict(cacheNames = "teacher", allEntries = true)
     @Operation(
             summary = "Atualiza um professor",
             description = "Atualiza os dados de um professor existente com base no ID informado. Campos nulos no DTO podem ser ignorados pelo mapper."
@@ -114,7 +109,6 @@ public class TeacherController {
     }
 
     @GetMapping
-    @Cacheable(cacheNames = "teacher", key = "#page + '_' + #size", unless = "#result == null")
     @Operation(
             summary = "Lista professores",
             description = "Retorna professores paginados. Pode retornar lista vazia."
@@ -128,16 +122,12 @@ public class TeacherController {
             @Parameter(description = "Quantidade de itens por página", example = "10")
             @RequestParam(defaultValue = "10") int size
     ) {
-        int pageNumber = Math.max(page, 0);
-        int pageSize = Math.max(size, 1);
-        Pageable pageable = PageRequest.of(pageNumber, pageSize);
-
-        Page<Teacher> teachers = teacherFacade.listAll(pageable);
-        List<TeacherResponseDTO> dtos = teachers.getContent()
-                .stream()
-                .map(teacherMapper::toDtoResponse)
-                .toList();
-        Page<TeacherResponseDTO> dtoPage = new PageImpl<>(dtos, teachers.getPageable(), teachers.getTotalElements());
+        TeacherPageResponseDTO cachedPage = teacherCacheService.listTeachers(page, size);
+        Page<TeacherResponseDTO> dtoPage = new PageImpl<>(
+                cachedPage.getContent(),
+                PageRequest.of(cachedPage.getPageNumber(), cachedPage.getPageSize()),
+                cachedPage.getTotalElements()
+        );
         return ResponseEntity.ok(dtoPage);
     }
 


### PR DESCRIPTION
## Summary
- replace cached PageImpl responses with a serializable TeacherPageResponseDTO to avoid Redis deserialization errors
- convert cached page DTOs back to Page objects only at the controller layer so Redis stores only DTO data
- document the cache behavior to keep ResponseEntity and PageImpl out of Redis payloads
- add cache error handling and startup cache clearing to evict any stale PageImpl/ResponseEntity entries during deserialization

## Testing
- mvn -DskipTests compile

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931f0353ae08321ac90d2b775c27b20)